### PR TITLE
Update all dependencies to latest

### DIFF
--- a/src/components/CalendarGrid.tsx
+++ b/src/components/CalendarGrid.tsx
@@ -95,7 +95,7 @@ export default function CalendarGrid({
                         <Link
                           key={index}
                           href={`/music/calendar/${event.note}`}
-                          className="inline-block w-full text-start text-sm bg-orange-400 dark:bg-orange-500/95 text-slate-900 px-1 rounded mb-1"
+                          className="inline-block w-full text-start text-sm bg-orange-400 dark:bg-orange-500/95 text-slate-900 dark:text-slate-900 px-1 rounded mb-1"
                         >
                           {fullEvent?.summary}
                         </Link>

--- a/src/components/CalendarPageContent.tsx
+++ b/src/components/CalendarPageContent.tsx
@@ -17,7 +17,7 @@ type CalendarMode = "grid" | "list";
 // const ONE_DAY_IN_MILLIS = 86_400_000;
 
 const buttonClasses =
-  "flex gap-x-2 items-center px-2 py-1 text-sm rounded aria-selected:bg-white text-black";
+  "flex gap-x-2 items-center px-2 py-1 text-sm rounded aria-selected:bg-white text-black dark:text-black";
 
 export default function CalendarPageContent({
   events,


### PR DESCRIPTION
## Summary

Updates all dependencies to their latest versions, including several major version bumps, along with the necessary migration work.

### Dependency upgrades

- **Next.js 15 → 16.2.7** — resolves a Vercel security block on 15.x; also required updating `@next/mdx` to 16.2.7 to fix a Turbopack build panic caused by an invalid `conditions` key injected by the older package
- **Tailwind CSS 3 → 4** — replaced `@tailwind` directives with `@import "tailwindcss"`, added `@tailwindcss/postcss`, removed `tailwind.config.ts` (content scanning is now automatic in v4)
- **ESLint 8 → 9** — migrated from `.eslintrc.json` to `eslint.config.js` (flat config); updated lint script since `next lint` was removed in Next.js 16; pinned to ESLint 9.x (ESLint 10 is incompatible with `eslint-plugin-react-hooks@4.6.2` bundled in `eslint-config-next`)
- **TypeScript 5 → 6**, **zod 3 → 4**, **date-fns 3 → 4**, **googleapis 105 → 173**, **lucide-react 0.x → 1.x**, **usehooks-ts 2 → 3**, **@vercel/analytics + speed-insights 1 → 2**, react/react-dom 19.1 → 19.2, and various other minor/patch bumps

### Bug fix

- **Invisible event labels in dark mode** — after the Tailwind v4 migration, `dark:text-white` on `body` was winning over `text-slate-900`/`text-black` set directly on child elements with orange backgrounds. Added explicit `dark:text-slate-900` / `dark:text-black` overrides on the event label links and calendar mode tab buttons.

### Cleanup

- Removed dead code: `src/hooks/useLocalStorage.ts` (unused, superseded by `usehooks-ts`)
- Added `.claude/settings.json` with permission allowlist

## Test plan

- [ ] Run `pnpm test` — all 12 tests pass
- [ ] Run `pnpm lint` — no errors
- [ ] Run `pnpm build` — builds successfully
- [ ] Verify event labels are visible in dark mode
- [ ] Verify calendar grid/list tab buttons are readable in dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)